### PR TITLE
Add nest and year selection to Shiny app

### DIFF
--- a/App/Zooniverse/predicted_nest_page.R
+++ b/App/Zooniverse/predicted_nest_page.R
@@ -9,6 +9,7 @@ predicted_nest_page<-function(nestdf){
       uiOutput('nest_year_selector'),
       plotOutput("nest_history_plot", height=400,width=700),
       uiOutput('nest_date_slider'),
+      uiOutput('nest_id_selector'),
       leafletOutput("nest_map", height=800,width=900)
     )})
 }

--- a/App/Zooniverse/predicted_nest_page.R
+++ b/App/Zooniverse/predicted_nest_page.R
@@ -6,6 +6,7 @@ predicted_nest_page<-function(nestdf){
       h2("Site Summary"),
       tableOutput("nest_summary_table"),
       selectInput("nest_site","Site",choices = unique(nestdf$Site),selected="StartMel"),
+      uiOutput('nest_year_selector'),
       plotOutput("nest_history_plot", height=400,width=700),
       uiOutput('nest_date_slider'),
       leafletOutput("nest_map", height=800,width=900)

--- a/App/Zooniverse/server.R
+++ b/App/Zooniverse/server.R
@@ -126,16 +126,25 @@ shinyServer(function(input, output, session) {
   ###Nest Page###
   nest_filter<-reactive({
     #filter based on selection
-    to_plot <- nestdf %>% filter(Site==input$nest_site) 
+    to_plot <- nestdf %>% filter(Site==input$nest_site, Year==input$nest_year)
     return(to_plot)
   })
   output$nest_summary_table <- renderTable(nest_summary_table(nestdf))
   output$nest_history_plot <- renderPlot(nest_history(nest_filter()))
   
+  #Reactive UI selector for years
+  output$nest_year_selector = renderUI({
+    selected_site <- as.character(input$nest_site)
+    selected_df <- nestdf %>% filter(Site==selected_site)
+    available_years<-sort(unique(selected_df$Year))
+    selectInput(inputId = "nest_year","Year",choices=available_years)
+  })
+
   #Reactive UI slider for dates
   output$nest_date_slider = renderUI({
     selected_site <- as.character(input$nest_site)
-    selected_df <- nestdf %>% filter(Site==selected_site)
+    selected_year <- input$nest_year
+    selected_df <- nestdf %>% filter(Site==selected_site, Year==selected_year)
     available_dates<-sort(unique(selected_df$Date))
     sliderTextInput(inputId = "nest_date","Select Date",choices=available_dates)
   })

--- a/App/Zooniverse/server.R
+++ b/App/Zooniverse/server.R
@@ -131,7 +131,7 @@ shinyServer(function(input, output, session) {
   })
   output$nest_summary_table <- renderTable(nest_summary_table(nestdf))
   output$nest_history_plot <- renderPlot(nest_history(nest_filter()))
-  
+
   #Reactive UI selector for years
   output$nest_year_selector = renderUI({
     selected_site <- as.character(input$nest_site)
@@ -149,6 +149,15 @@ shinyServer(function(input, output, session) {
     sliderTextInput(inputId = "nest_date","Select Date",choices=available_dates)
   })
   
+  #Reactive UI selector for Nest IDs
+  output$nest_id_selector = renderUI({
+    selected_site <- as.character(input$nest_site)
+    selected_year <- input$nest_year
+    selected_df <- nestdf %>% filter(Site==selected_site, Year==selected_year)
+    available_nests<-sort(unique(selected_df$target_ind))
+    selectInput(inputId = "nest_ids","Nest IDs", multiple=TRUE, choices=available_nests, selected=available_nests)
+  })
+
   #Default plot
   output$nest_map<-renderLeaflet(plot_nests(nestdf %>% filter(Site=="Joule",Date==min(Date)),MAPBOX_ACCESS_TOKEN))
   
@@ -156,7 +165,7 @@ shinyServer(function(input, output, session) {
     selected_nests<-nestdf %>% filter(Site == input$nest_site)
     return(selected_nests)
   })
-  
+
   nest_map_date_filter<-reactive({
     selected_nests<-nestdf %>% filter(Date == input$nest_date)
     return(selected_nests)
@@ -166,11 +175,16 @@ shinyServer(function(input, output, session) {
     selected_nests<-nest_map_site_filter()
     output$nest_map<-renderLeaflet(plot_nests(selected_nests %>% filter(Date==min(Date)),MAPBOX_ACCESS_TOKEN))
   })
-  
+
   observeEvent(input$nest_date,{
     selected_nests<-nest_map_date_filter()
-    selected_nests<-selected_nests %>% filter(Site==input$nest_site)
+    selected_nests<-selected_nests %>% filter(Site==input$nest_site, target_ind %in% as.numeric(input$nest_ids))
     update_nests(selected_nests, MAPBOX_ACCESS_TOKEN)
   })
-  
+
+  observeEvent(input$nest_ids,{
+    selected_nests<-nest_map_date_filter()
+    selected_nests<-selected_nests %>% filter(Site==input$nest_site, target_ind %in% as.numeric(input$nest_ids))
+    update_nests(selected_nests, MAPBOX_ACCESS_TOKEN)
+  })
 })


### PR DESCRIPTION
Support finer grain assessment of bird-bird-bird for best detection by
allowing users to subset based on year and nest ID.