### PR TITLE
Show tiles when no nests are present

### DIFF
--- a/App/Zooniverse/functions.R
+++ b/App/Zooniverse/functions.R
@@ -153,8 +153,7 @@ plot_nests<-function(df, MAPBOX_ACCESS_TOKEN){
   return(m)
 }
 
-update_nests<-function(df, MAPBOX_ACCESS_TOKEN){
-  mapbox_tileset<-unique(df$tileset_id)[1]
+update_nests<-function(mapbox_tileset, df, MAPBOX_ACCESS_TOKEN){
   mapbox_tileset<-paste("bweinstein.",mapbox_tileset,sep="")
     leafletProxy("nest_map")  %>% clearShapes() %>%
      addProviderTiles("MapBox", layerId = "mapbox_id",options = providerTileOptions(id = mapbox_tileset, minZoom = 8, maxNativeZoom=24, maxZoom = 24, accessToken = MAPBOX_ACCESS_TOKEN)) %>%

--- a/App/Zooniverse/server.R
+++ b/App/Zooniverse/server.R
@@ -178,13 +178,17 @@ shinyServer(function(input, output, session) {
 
   observeEvent(input$nest_date,{
     selected_nests<-nest_map_date_filter()
-    selected_nests<-selected_nests %>% filter(Site==input$nest_site, target_ind %in% as.numeric(input$nest_ids))
-    update_nests(selected_nests, MAPBOX_ACCESS_TOKEN)
+    selected_nests<-selected_nests %>% filter(Site==input$nest_site)
+    mapbox_tileset<-unique(selected_nests$tileset_id)[1]
+    selected_nests<-selected_nests %>% filter(target_ind %in% as.numeric(input$nest_ids))
+    update_nests(mapbox_tileset, selected_nests, MAPBOX_ACCESS_TOKEN)
   })
 
   observeEvent(input$nest_ids,{
     selected_nests<-nest_map_date_filter()
-    selected_nests<-selected_nests %>% filter(Site==input$nest_site, target_ind %in% as.numeric(input$nest_ids))
-    update_nests(selected_nests, MAPBOX_ACCESS_TOKEN)
+    selected_nests<-selected_nests %>% filter(Site==input$nest_site)
+    mapbox_tileset<-unique(selected_nests$tileset_id)[1]
+    selected_nests<-selected_nests %>% filter(target_ind %in% as.numeric(input$nest_ids))
+    update_nests(mapbox_tileset, selected_nests, MAPBOX_ACCESS_TOKEN)
   })
 })


### PR DESCRIPTION
When focusing on a single nest if a bird is not detected at the
nest site on the selected date the RGB tile wasn't shown because the
data frame that the tile ids where harvested from is empty.

This change gets the tile ids before filtering the nests to avoid this
issue.