### PR TITLE
Improve efficiency  of majority rule calculation

### DIFF
--- a/App/Zooniverse/functions.R
+++ b/App/Zooniverse/functions.R
@@ -35,8 +35,15 @@ filter_annotations<-function(raw_data){
   selected_ids<-unique(raw_data$selected_i)
   
   #Majority rule for labels
-  majority_rule<-raw_data %>% group_by(selected_i, label) %>% summarize(n=n()) %>% arrange(desc(n)) %>% slice(1) %>% as.data.frame() %>% mutate(majority_class=label) %>%
-    dplyr::select(selected_i,majority_class)
+  majority_rule<-raw_data %>%
+                 data.frame() %>% # Converting to a non-spatial data frame improves speed 100-200x
+                 group_by(selected_i, label) %>%
+                 summarize(n=n()) %>%
+                 arrange(desc(n)) %>%
+                 slice(1) %>%
+                 as.data.frame() %>%
+                 mutate(majority_class=label) %>%
+                 dplyr::select(selected_i,majority_class)
   
   selected_boxes<-raw_data %>% filter(selected_i %in% selected_ids) %>% inner_join(majority_rule) %>% filter(!is.na(event))
   


### PR DESCRIPTION
The majority_rule calculation in filter_annotations was very slow
(~4 minutes locally). Switch to regular (non-spatial) data frame for
this dplyr pipeline makes it almost instantaneous.

Co-authored-by: Ben Weinstein <benweinstein2010@gmail.com>

Closes #29