### PR TITLE
Use R to get unique sites for shiny landing page

### DIFF
--- a/App/Zooniverse/landing_page.R
+++ b/App/Zooniverse/landing_page.R
@@ -1,6 +1,6 @@
 landing_page<-function(selected_boxes){
   
-  site_list<-c("All",selected_boxes$site)
+  site_list<-c("All", unique(selected_boxes$site))
   select_image_list<-unique(selected_boxes$tileset_id)
   
   renderUI({


### PR DESCRIPTION
There was a missing `unique()` when generating the site list for the
landing page. This meant that JavaScript was being used to generate the
unique list (see https://shiny.rstudio.com/articles/selectize.html),
which is slow. Adding the unique significantly decreases build time.