### PR TITLE
Allow shiny app to build on Windows

### DIFF
--- a/App/Zooniverse/server.R
+++ b/App/Zooniverse/server.R
@@ -28,7 +28,7 @@ shinyServer(function(input, output, session) {
   MAPBOX_ACCESS_TOKEN=Sys.getenv("MAPBOX_ACCESS_TOKEN")
   
   #Predictions
-  unzip("data/PredictedBirds.zip", exdir = "data/")
+  unzip("data/PredictedBirds.zip", exdir = "data")
   df<-st_read("data/PredictedBirds.shp")
   df$event<-as.Date(df$event,"%m_%d_%Y")
   df$tileset_id<-construct_id(df$site,df$event)


### PR DESCRIPTION
Including a trailing slash in the exdir argument for unzip causes a
directory not found error on Windows. This removes that slash for
cross-platform compatibility.