### PR TITLE
Make nest counts and displayed nests match

### DIFF
--- a/App/Zooniverse/functions.R
+++ b/App/Zooniverse/functions.R
@@ -129,9 +129,14 @@ compare_counts<-function(df, selected_boxes){
 }
 
 ##Nest detection
-nest_summary_table<-function(nestdf){
-  nest_table <- nestdf %>% as.data.frame() %>% group_by(Site, target_ind) %>% 
-    summarize(n=n()) %>% filter(n>3) %>% group_by(Site) %>% summarize(Nests=n(), Average_Detections = mean(n)) 
+nest_summary_table<-function(nestdf, min_detections){
+  nest_table <- nestdf %>%
+                  as.data.frame() %>%
+                  group_by(Site, target_ind) %>%
+                  summarize(n=n()) %>%
+                  filter(n >= min_detections) %>%
+                  group_by(Site) %>%
+                  summarize(Nests=n(), Average_Detections = mean(n)) 
   return(nest_table)
 }
 


### PR DESCRIPTION
These two counts were being filtered differently. This change shifts
the filtering decisisions to two clearly definited variables that are
used in the relevant places.

Also some dplyr style cleanup in the changed pipelines:
https://style.tidyverse.org/pipes.html

Fixes #43