### PR TITLE
Empty images are only empty is all annotators agree

### DIFF
--- a/Zooniverse/extract.py
+++ b/Zooniverse/extract.py
@@ -31,7 +31,8 @@ def extract_empty(parsed_data, image_data,save_dir="."):
     df = pd.read_csv(parsed_data)
     
     #get empty frames
-    df = df[df.species.isna()]
+    is_empty = df.groupby(["subject_ids"]).apply(lambda x: sum(~x.species.isna())==0)
+    df = df[df.subject_ids.isin(is_empty[is_empty == True].index)]
     df["subject_id"] = df.subject_ids.astype(int)
         
     #Read in image location data


### PR DESCRIPTION
When extracting empty images we were previously identifying any images
that was marked as empty by any annotator, but in some cases one
annotator will see a bird and another annotator won't. This change only
identifies a frame as empty if no annotator has identified a bird in it.

Co-authored-by: Ben Weinstein <benweinstein2010@gmail.com>