### PR TITLE
Add selecting and zooming to bird

### DIFF
--- a/App/Zooniverse/functions.R
+++ b/App/Zooniverse/functions.R
@@ -167,13 +167,28 @@ plot_nests<-function(df, bird_df, MAPBOX_ACCESS_TOKEN){
   return(m)
 }
 
-update_nests<-function(mapbox_tileset, df, bird_df, MAPBOX_ACCESS_TOKEN){
+update_nests<-function(mapbox_tileset, df, bird_df,
+                       MAPBOX_ACCESS_TOKEN, bird_data_last_selected = NULL){
   mapbox_tileset<-paste("bweinstein.",mapbox_tileset,sep="")
+  bird_location <- bird_data_last_selected$geometry[[1]]
+  lng <- bird_location[1]
+  lat <- bird_location[2]
+  zoom <- 24
+  if (is.null(lng) | is.null(lat) | is.null(zoom) | is.null(bird_data_last_selected)){    
     leafletProxy("nest_map")  %>% clearShapes() %>%
-     addProviderTiles("MapBox", layerId = "mapbox_id",options = providerTileOptions(id = mapbox_tileset, minZoom = 8, maxNativeZoom=24, maxZoom = 24, accessToken = MAPBOX_ACCESS_TOKEN)) %>%
+      addProviderTiles("MapBox", layerId = "mapbox_id",options = providerTileOptions(id = mapbox_tileset, minZoom = 8, maxNativeZoom=24, maxZoom = 24, accessToken = MAPBOX_ACCESS_TOKEN)) %>%
       addCircles(data=df,stroke = T,fillOpacity = 0.1,radius = 0.5,popup = ~htmlEscape(paste(Date,round(score,2),target_ind,sep=", "))) %>%
       addCircles(data = bird_df, stroke = T, fillOpacity = 0, radius = 0.2, color = "red",
                  popup = ~htmlEscape(paste(round(score,2), bird_id, sep=":")))
+  } else {
+    leafletProxy("nest_map")  %>% clearShapes() %>%
+      addProviderTiles("MapBox", layerId = "mapbox_id",options = providerTileOptions(id = mapbox_tileset, minZoom = 8, maxNativeZoom=24, maxZoom = 24, accessToken = MAPBOX_ACCESS_TOKEN)) %>%
+      addCircles(data=df,stroke = T,fillOpacity = 0.1,radius = 0.5,popup = ~htmlEscape(paste(Date,round(score,2),target_ind,sep=", "))) %>%
+      addCircles(data = bird_df, stroke = T, fillOpacity = 0, radius = 0.2, color = "red",
+                 popup = ~htmlEscape(paste(round(score,2), bird_id, sep=":"))) %>%
+      addCircles(data = bird_data_last_selected, stroke = T, fillOpacity = 0, radius = 1) %>%
+      setView(lng, lat, zoom)
+  }
 }
 
 #Construct mapbox url

--- a/App/Zooniverse/predicted_nest_page.R
+++ b/App/Zooniverse/predicted_nest_page.R
@@ -9,6 +9,7 @@ predicted_nest_page<-function(nestdf){
       uiOutput('nest_year_selector'),
       plotOutput("nest_history_plot", height=400,width=700),
       uiOutput('nest_id_selector'),
+      uiOutput('bird_id_selector'),
       uiOutput('nest_date_slider'),
       leafletOutput("nest_map", height=800,width=900)
     )})


### PR DESCRIPTION
To support evaluation of nest detector allow the selection of
individual bird detections, zoom to that location, and represent that
location with a large circle that persists with date changes.

Co-authored-by: Morgan Ernest <morgan@weecology.org>