### PR TITLE
Move random field nest sampling to EvergladesWadingBird repo

### DIFF
--- a/App/Zooniverse/load_data.R
+++ b/App/Zooniverse/load_data.R
@@ -12,13 +12,9 @@ colonies <- st_read(
   "data/colonies.csv",
   options = c("X_POSSIBLE_NAMES=longitude","Y_POSSIBLE_NAMES=latitude"))
 field_nests <- st_read(
-  "https://raw.githubusercontent.com/weecology/EvergladesWadingBird/main/Nesting/UAV_Flagged_Nest_Coordinates_2021.csv",
+  "https://raw.githubusercontent.com/weecology/EvergladesWadingBird/main/Nesting/field_nest_sample_locations.csv",
   options = c("X_POSSIBLE_NAMES=long", "Y_POSSIBLE_NAMES=lat"),
   crs = 4326)
-field_nests <- field_nests %>%
-  rename(site = colony) %>%
-  mutate(year = 2021)
-field_nests$site <- trimws(field_nests$site) # There is currently an extra space in at least one value of site
 
 #Predictions
 unzip("data/PredictedBirds.zip", exdir = "data")
@@ -48,26 +44,3 @@ selected_indices <- nestdf %>%
 nestdf <- nestdf %>%
   mutate(site_index = paste(Site,target_ind)) %>%
   inner_join(selected_indices)
-
-# Add random bird locations to field nests
-
-num_field_nests <- nrow(field_nests)
-field_nest_sites <- unique(field_nests$site)
-field_nest_years <- unique(field_nests$year)
-
-set.seed(26) # Keep same nest number and fake nest locations across runs
-
-random_birds <- df %>%
-  filter(site %in% field_nest_sites, year %in% field_nest_years) %>%
-  mutate(real_nest = "No") %>%
-  select(site, year, species = label, real_nest) %>%
-  slice(sample(1:num_field_nests))
-
-field_nests <- field_nests %>%
-  mutate(real_nest = "Yes") %>%
-  select(site, year, species, real_nest) %>%
-  rbind(random_birds) %>%
-  slice(sample(1:n())) %>% # Randomize order to not give clues to real nests
-  mutate(field_nest_id = seq_len(n()))
-
-field_nests

--- a/App/Zooniverse/predicted_nest_page.R
+++ b/App/Zooniverse/predicted_nest_page.R
@@ -11,7 +11,7 @@ predicted_nest_page<-function(nestdf){
       #plotOutput("nest_history_plot", height=400,width=700),
       uiOutput('nest_id_selector'),
       uiOutput('bird_id_selector'),
-      uiOutput('field_nest_id_selector'),
+      uiOutput('field_nest_samp_id_selector'),
       uiOutput('nest_date_slider'),
       leafletOutput("nest_map", height=800,width=900)
     )})

--- a/App/Zooniverse/server.R
+++ b/App/Zooniverse/server.R
@@ -6,6 +6,7 @@ library(shiny)
 library(shinyWidgets)
 library(htmltools)
 library(sf)
+library(stringr)
 
 #Source page UIs
 source("landing_page.R")
@@ -170,12 +171,12 @@ shinyServer(function(input, output, session) {
   })
 
   #Reactive UI selector for Field Nest IDs
-  output$field_nest_id_selector <- renderUI({
+  output$field_nest_samp_id_selector <- renderUI({
     selected_site <- as.character(input$nest_site)
     selected_year <- input$nest_year
     selected_field_nests <- field_nests %>% filter(site==selected_site, year==selected_year)
-    available_nests <- sort(unique(selected_field_nests$field_nest_id))
-    pickerInput(inputId = "field_nest_ids",
+    available_nests <- str_sort(unique(selected_field_nests$sample_id), numeric = TRUE)
+    pickerInput(inputId = "field_nest_samp_ids",
                 label = "Field Nest IDs",
                 multiple = TRUE,
                 choices = available_nests,
@@ -285,7 +286,7 @@ shinyServer(function(input, output, session) {
       filter(label %in% input$species)
     selected_field_nests <- field_nests_site_filter() %>%
       filter(year == input$nest_year) %>%
-      filter(field_nest_id %in% as.numeric(input$field_nest_ids))
+      filter(sample_id %in% as.numeric(input$field_nest_samp_ids))
     mapbox_tileset<-unique(selected_nests$tileset_id)[1]
 
     if (length(input$bird_ids) == 1){
@@ -303,7 +304,7 @@ shinyServer(function(input, output, session) {
                   focal_position)
   })
 
-  observeEvent(input$field_nest_ids,{
+  observeEvent(input$field_nest_samp_ids,{
     selected_nests <- nest_map_date_filter() %>%
       filter(Site==input$nest_site)
     selected_birds <- bird_map_date_filter() %>%
@@ -311,12 +312,12 @@ shinyServer(function(input, output, session) {
       filter(label %in% input$species)
     selected_field_nests <- field_nests_site_filter() %>%
       filter(year == input$nest_year) %>%
-      filter(field_nest_id %in% as.numeric(input$field_nest_ids))
+      filter(sample_id %in% as.numeric(input$field_nest_samp_ids))
     mapbox_tileset <- unique(selected_nests$tileset_id)[1]
 
-    if (length(input$field_nest_ids) == 1){
+    if (length(input$field_nest_samp_ids) == 1){
       focal_field_nest <- selected_field_nests %>%
-        filter(field_nest_id == input$field_nest_ids)
+        filter(sample_id == input$field_nest_samp_ids)
       focal_position <<- focal_field_nest$geometry[[1]]
     } else {
       focal_position <- NULL


### PR DESCRIPTION
To support consistent links between random samples for evaluating field
nests this moves the associated code into the EvergladesWadingBird repo
where consistent sample IDs are created and stored. This app now just
loads those sample locations and provides them to the user.