### PR TITLE
Handle primary and non-primary flights differently

### DIFF
--- a/Zooniverse/Snakefile
+++ b/Zooniverse/Snakefile
@@ -1,5 +1,6 @@
 import glob
 import os
+import tools
 
 ORTHOMOSAICS = glob_wildcards("/blue/ewhite/everglades/orthomosaics/{year}/{site}/{flight}.tif")
 FLIGHTS = ORTHOMOSAICS.flight
@@ -50,8 +51,9 @@ def flights_in_year_site(wildcards):
     basepath = "/blue/ewhite/everglades/predictions"
     flights_in_year_site = []
     for site, year, flight in zip(SITES, YEARS, FLIGHTS):
-        if site == wildcards.site and year == wildcards.year:
-            flight_path = os.path.join(basepath, year, site, f"{flight}_projected.shp")
+        flight_path = os.path.join(basepath, year, site, f"{flight}_projected.shp")
+        event = tools.get_event(flight_path)
+        if site == wildcards.site and year == wildcards.year and event == "primary":
             flights_in_year_site.append(flight_path)
     return flights_in_year_site
 

--- a/Zooniverse/combine_bird_predictions.py
+++ b/Zooniverse/combine_bird_predictions.py
@@ -3,33 +3,21 @@ import os
 import re
 from zipfile import ZIP_DEFLATED
 from zipfile import ZipFile
-
 import geopandas
 import pandas as pd
 
+import tools
 
 def find_shp_files(predictions_path):
     files = glob.glob(os.path.join(predictions_path, '**', '**', '*_projected.shp'))
     return files
 
 
-def get_site(path):
-    path = os.path.basename(path)
-    regex = re.compile("(\\w+)_\\d+_\\d+_\\d+.*_projected")
-    return regex.match(path).group(1)
-
-
-def get_event(path):
-    path = os.path.basename(path)
-    regex = re.compile('\\w+_(\\d+_\\d+_\\d+).*_projected')
-    return regex.match(path).group(1)
-
-
 def load_shapefile(x):
-    print(x)
     shp = geopandas.read_file(x)
-    shp["site"] = get_site(x)
-    shp["event"] = get_event(x)
+    shp["site"] = tools.get_site(x)
+    shp["date"] = tools.get_date(x)
+    shp["event"] = tools.get_event(x)
     return shp
 
 

--- a/Zooniverse/tools.py
+++ b/Zooniverse/tools.py
@@ -1,0 +1,33 @@
+import os
+import re
+
+def get_date(path):
+    path = os.path.basename(path)
+    regex = re.compile('\\w+_(\\d+_\\d+_\\d+).*_projected')
+    return regex.match(path).group(1)
+
+def get_event(path):
+    """
+    Determines the event for a given UAS flight
+
+    When there is only one event, the event is not typically recorded in the file name.
+    So, values for path are of the general form:
+    /path/to/file/site_month_day_year_projected.shp
+    or
+    /path/to/file/site_month_day_year_event_projected.shp
+
+    This function returns "primary" for no event and events with the following values:
+    "A", "a", "primary", "PRIMARY", or mixed case versions of "primary"
+    """
+    path = os.path.basename(path)
+    regex = re.compile('\\w+_\\d+_\\d+_\\d+_(\\w+)_projected')
+    match = regex.match(path)
+    if match and match.group(1).upper() != "A" and match.group(1).upper() != "PRIMARY":
+        return match.group(1)
+    else:
+        return "primary"
+
+def get_site(path):
+    path = os.path.basename(path)
+    regex = re.compile("(\\w+)_\\d+_\\d+_\\d+.*_projected")
+    return regex.match(path).group(1)

--- a/Zooniverse/upload_mapbox.py
+++ b/Zooniverse/upload_mapbox.py
@@ -3,6 +3,7 @@ import requests
 import sys
 import subprocess
 import tomli
+import tools
 
 import rasterio as rio
 from rasterio.warp import calculate_default_transform, reproject, Resampling
@@ -22,6 +23,9 @@ def upload(path, year, site, force_upload=False):
     # Create output filename
     basename = os.path.splitext(os.path.basename(path))[0]
     flight = basename.replace("_projected", "")
+    if tools.get_event(basename) == "Primary":
+        # If from the primary flight strip any extra metadata from filename
+        flight = "_".join(basename.split('_')[0:4])
     mbtiles_dir = os.path.join("/blue/ewhite/everglades/mapbox/", year, site)
     if not os.path.exists(mbtiles_dir):
         os.makedirs(mbtiles_dir)


### PR DESCRIPTION
Use a naming convention to identify primary and non-primary flights and process them differently. Non-primary flights are secondary flights on the same date (e.g., to test a different instrument) or flights that are partial or otherwise should be used for core things like counts and nest detection.