### PR TITLE
[WIP] adding auth page for current year nests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ App/.R*
 *.Rproj*
 *.RData*
 
+.Rproj.user

--- a/App/Zooniverse/secured_nest_page.R
+++ b/App/Zooniverse/secured_nest_page.R
@@ -1,0 +1,23 @@
+library(shinymanager)
+
+current_nest_page<-function(nestdf){
+  ui<-renderUI({
+    fluidPage(
+      auth_ui("auth"),
+      verbatimTextOutput(outputId = "res_auth"),
+      titlePanel("Current Bird & Nest Detections"),
+      fluidRow(
+        column(width = 2, selectInput("nest_site","Site",choices = unique(nestdf$Site),selected="StartMel")),
+        column(width = 2, uiOutput('nest_year_selector'))
+      ),
+      uiOutput("species_selector"),
+      h5("Show:"),
+      fluidRow(
+        column(width = 1, uiOutput('bird_selector')),
+        column(width = 1, uiOutput('nest_selector'))
+      ),
+      uiOutput('samp_id_selector'),
+      uiOutput('date_slider'),
+      leafletOutput("nest_map", height=800,width=900)
+    )})
+}

--- a/App/Zooniverse/ui.R
+++ b/App/Zooniverse/ui.R
@@ -10,12 +10,13 @@ library(shinythemes)
 
 # Define UI for application that draws a histogram
 shinyUI(fluidPage(theme = shinytheme("readable"),
-                  
+
                   #Navbar to each page
                   navbarPage("Everglades Wading Birds",
                              tabPanel("Zooniverse",uiOutput('landing')),
                              tabPanel("Time Series",uiOutput('time')),
                              tabPanel("Predicted Counts",uiOutput('predicted')),
                              tabPanel("Predicted Nests",uiOutput('predicted_nests')),
+                             tabPanel("Current Nests",uiOutput('current_nests')),
                              tabPanel("About",uiOutput('about'))
                   )))


### PR DESCRIPTION
To do list for completing this.

- [ ] hide usernames on file, hashed? They are currently plain text.
- [ ] Remove the current year data from predicted_nest_page
- [ ] Do we need to do this for predicted counts? Combine the two pages?
- [ ] A message in the predicted_nest_page directing them to the current nest page?  